### PR TITLE
Use bull v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ sudo: false
 node_js:
   - "stable"
   - "4.2"
-  - "2.5"
-  - "0.12"
   - "iojs"
 
 services:

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "bluebird": "2.10.x",
     "body-parser": "1.14.x",
     "bootstrap": "3.3.x",
-    "bull": "git+https://github.com/Epharmix/bull.git#master",
+    "bull": "^2.0.0",
     "classnames": "2.1.x",
     "connect-slashes": "1.3.x",
     "express": "4.13.x",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "type": "git",
     "url": "git+https://github.com/evanhuang8/Toureiro.git"
   },
+  "engines": {
+    "node" : ">=4.2"
+  },
   "keywords": [
     "bull",
     "distributed",

--- a/tests/test_models.js
+++ b/tests/test_models.js
@@ -51,7 +51,7 @@ describe('Models', function() {
   });
 
   describe('Queue', function() {
-  
+
     var Queue = require('../lib/models/queue');
 
     beforeEach(function(done) {
@@ -135,7 +135,7 @@ describe('Models', function() {
           // ids are reversed since it's LIFO
           var ids = [15, 14, 13, 12, 11, 10, 9];
           _.map(jobs, function(job) {
-            expect(ids.indexOf(job.jobId)).to.not.equal(-1);
+            expect(ids.indexOf(Number(job.jobId))).to.not.equal(-1);
           });
           done();
         });
@@ -174,7 +174,7 @@ describe('Models', function() {
           expect(jobs.length).to.equal(3);
           var ids = [2, 3, 4];
           _.map(jobs, function(job) {
-            expect(ids.indexOf(job.jobId)).to.not.equal(-1);
+            expect(ids.indexOf(Number(job.jobId))).to.not.equal(-1);
           });
           done();
         });
@@ -215,7 +215,7 @@ describe('Models', function() {
           expect(jobs.length).to.equal(4);
           var ids = [1, 2, 3, 4];
           _.map(jobs, function(job) {
-            expect(ids.indexOf(job.jobId)).to.not.equal(-1);
+            expect(ids.indexOf(Number(job.jobId))).to.not.equal(-1);
           });
           done();
         });
@@ -252,7 +252,7 @@ describe('Models', function() {
           expect(jobs.length).to.equal(5);
           var ids = [2, 3, 4, 5, 6];
           _.map(jobs, function(job) {
-            expect(ids.indexOf(job.jobId)).to.not.equal(-1);
+            expect(ids.indexOf(Number(job.jobId))).to.not.equal(-1);
           });
           done();
         });
@@ -291,7 +291,7 @@ describe('Models', function() {
           expect(jobs.length).to.equal(7);
           var ids = [4, 5, 6, 7, 8, 9, 10];
           _.map(jobs, function(job) {
-            expect(ids.indexOf(job.jobId)).to.not.equal(-1);
+            expect(ids.indexOf(Number(job.jobId))).to.not.equal(-1);
           });
           done();
         });


### PR DESCRIPTION
- Affixes to next major version of bull
- Drops support for node <= 4.2
- Fixes tests & CI